### PR TITLE
Fix for 4 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,7 @@
     "knox": "~0.9.2",
     "walk": "~2.2.1",
     "async": "~0.2.9",
-    "request": "~2.16.6",
+    "request": "~2.74.0",
     "uglify-js": "~2.4.3",
     "underscore.string": "~2.3.1"
   },
@@ -122,7 +122,7 @@
     "optipng-bin": "3.1.2",
     "jpegtran-bin": "~3.0.6",
     "knox": "~0.9.2",
-    "request": "~2.16.6",
+    "request": "~2.74.0",
     "underscore.string": "~2.3.1",
     "clean-css":"2.0.2"
   },


### PR DESCRIPTION
express-cdn currently has a 6 vulnerable dependency paths, introducing 6 different types of known vulnerabilities.

This PR fixes vulnerable dependencies, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency, [ReDos vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency,[Dos(Memory Exhaustion) vulnerability](https://snyk.io/vuln/npm:qs:20140806) and [Dos(Event Loop Blocking) vulnerability](https://snyk.io/vuln/npm:qs:20140806-1) in the `qs` dependency.

You can see [Snyk test report](https://snyk.io/test/github/niftylettuce/express-cdn) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade other dependencies as well.

Stay Secure,
The Snyk Team
